### PR TITLE
fix: CGD-238: BPN from access_token ignore case

### DIFF
--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/BaseController.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/controller/BaseController.java
@@ -28,6 +28,8 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 import java.security.Principal;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * The type Base controller.
@@ -44,8 +46,11 @@ public class BaseController {
         Object principal1 = ((JwtAuthenticationToken) principal).getPrincipal();
         Jwt jwt = (Jwt) principal1;
 
-        Validate.isFalse(jwt.getClaims().containsKey(StringPool.BPN_UPPER_CASE)).launch(new ForbiddenException("Invalid token, BPN not found"));
-
-        return jwt.getClaims().get(StringPool.BPN_UPPER_CASE).toString();
+        //this will misbehave if we have more then one claims with different case
+        // ie. BPN=123456 and bpn=789456
+        Map<String, Object> claims = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        claims.putAll(jwt.getClaims());
+        Validate.isFalse(claims.containsKey(StringPool.BPN)).launch(new ForbiddenException("Invalid token, BPN not found"));
+        return claims.get(StringPool.BPN).toString();
     }
 }

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/AuthenticationUtils.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/AuthenticationUtils.java
@@ -33,6 +33,7 @@ import org.springframework.http.HttpHeaders;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 
 public class AuthenticationUtils {
@@ -80,6 +81,12 @@ public class AuthenticationUtils {
 
 
     private static String getJwtToken(String username, String bpn) {
+
+        List<String> list = List.of("BPN", "bpn", "bPn"); //Do not add more field here, if you do make sure you change in keycloak realm file
+        Random randomizer = new Random();
+        String attributeName = list.get(randomizer.nextInt(list.size()));
+        System.out.println("attributeName---------------------->" + attributeName);
+
         Keycloak keycloak = KeycloakBuilder.builder()
                 .serverUrl(TestContextInitializer.getAuthServerUrl())
                 .realm(StringPool.REALM)
@@ -96,7 +103,7 @@ public class AuthenticationUtils {
         UserResource userResource = realmResource.users().get(userRepresentations.get(0).getId());
         userRepresentation.setEmailVerified(true);
         userRepresentation.setEnabled(true);
-        userRepresentation.setAttributes(Map.of(StringPool.BPN_UPPER_CASE, List.of(bpn)));
+        userRepresentation.setAttributes(Map.of(attributeName, List.of(bpn)));
         userResource.update(userRepresentation);
         return getJwtToken(username);
     }

--- a/src/test/resources/miw-test-realm.json
+++ b/src/test/resources/miw-test-realm.json
@@ -781,6 +781,38 @@
           }
         },
         {
+          "id": "c46e9cc6-3057-4640-a78b-e12fc3a723df",
+          "name": "bpn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "false",
+            "userinfo.token.claim": "true",
+            "multivalued": "false",
+            "user.attribute": "bpn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bpn"
+          }
+        },
+        {
+          "id": "c46e9cc6-3057-4640-a78b-e12fc3a814df",
+          "name": "bPn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "false",
+            "userinfo.token.claim": "true",
+            "multivalued": "false",
+            "user.attribute": "bPn",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bPn"
+          }
+        },
+        {
           "id": "1340463e-a737-4507-8ecb-b01715a9fde4",
           "name": "Client IP Address",
           "protocol": "openid-connect",


### PR DESCRIPTION
**Fix:**

Get BPN from access token ignore case manner  ref: https://jira.catena-x.net/browse/CGD-238

**Test case**
![Screenshot from 2023-06-19 16-59-41](https://github.com/catenax-ng/tx-managed-identity-wallets/assets/45592624/6689580a-2c89-4a54-a785-5e26d8ffbb02)
![Screenshot from 2023-06-19 16-59-18](https://github.com/catenax-ng/tx-managed-identity-wallets/assets/45592624/727f6d4b-1cd7-4e36-a87c-4ad6313f23c2)
