### PR TITLE
update vp-jwt subject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${openApiVersion}"
 	implementation group: 'com.smartsensesolutions', name: 'commons-dao', version: '0.0.5'
 	implementation 'org.liquibase:liquibase-core'
-	implementation 'org.eclipse.tractusx.ssi:cx-ssi-lib:0.0.6'
+	implementation 'org.eclipse.tractusx.ssi:cx-ssi-lib:0.0.7'
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/Wallet.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/Wallet.java
@@ -29,8 +29,6 @@ import org.eclipse.tractusx.managedidentitywallets.utils.StringToDidDocumentConv
 import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 
-import java.net.URLDecoder;
-import java.nio.charset.Charset;
 import java.util.List;
 
 /**
@@ -66,16 +64,6 @@ public class Wallet extends MIWBaseEntity {
     @Convert(converter = StringToDidDocumentConverter.class)
     private DidDocument didDocument;
 
-
     @Transient
     private List<VerifiableCredential> verifiableCredentials;
-
-    /**
-     * Sets did.
-     *
-     * @param did the did
-     */
-    public void setDid(String did) {
-        this.did = URLDecoder.decode(did, Charset.defaultCharset());
-    }
 }

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/CommonService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/CommonService.java
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletReposito
 import org.eclipse.tractusx.managedidentitywallets.exception.WalletNotFoundProblem;
 import org.eclipse.tractusx.managedidentitywallets.utils.CommonUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.Validate;
+import org.eclipse.tractusx.ssi.lib.exception.DidParseException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -49,7 +50,12 @@ public class CommonService {
         if (CommonUtils.getIdentifierType(identifier).equals(StringPool.BPN)) {
             wallet = walletRepository.getByBpn(identifier);
         } else {
-            wallet = walletRepository.getByDid(identifier);
+            try {
+                wallet = walletRepository.getByDid(identifier);
+            } catch (DidParseException e) {
+                log.error("Error while parsing did {}", identifier, e);
+                throw new WalletNotFoundProblem("Error while parsing did " + identifier);
+            }
         }
         Validate.isNull(wallet).launch(new WalletNotFoundProblem("Wallet not found for identifier " + identifier));
         return wallet;

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/HoldersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/HoldersCredentialService.java
@@ -104,11 +104,11 @@ public class HoldersCredentialService extends BaseService<HoldersCredential, Lon
 
         //Holder must be caller of API
         Wallet holderWallet = commonService.getWalletByIdentifier(callerBPN);
-        filterRequest.appendCriteria(StringPool.HOLDER_DID, Operator.EQUALS, holderWallet.getDid());
+        filterRequest.appendCriteria(StringPool.HOLDER_DID, Operator.EQUALS, holderWallet.getDid().toString());
 
         if (StringUtils.hasText(issuerIdentifier)) {
             Wallet issuerWallet = commonService.getWalletByIdentifier(issuerIdentifier);
-            filterRequest.appendCriteria(StringPool.ISSUER_DID, Operator.EQUALS, issuerWallet.getDid());
+            filterRequest.appendCriteria(StringPool.ISSUER_DID, Operator.EQUALS, issuerWallet.getDid().toString());
         }
 
         if (StringUtils.hasText(credentialId)) {

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletKeyService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/WalletKeyService.java
@@ -27,7 +27,7 @@ import com.smartsensesolutions.java.commons.specification.SpecificationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.bouncycastle.util.io.pem.PemReader;
+import org.bouncycastle.util.encoders.Base64;
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.WalletKey;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletKeyRepository;
 import org.eclipse.tractusx.managedidentitywallets.utils.EncryptionUtils;
@@ -60,7 +60,6 @@ public class WalletKeyService extends BaseService<WalletKey, Long> {
         return specificationUtil;
     }
 
-
     /**
      * Get private key by wallet identifier as bytes byte [ ].
      *
@@ -83,7 +82,7 @@ public class WalletKeyService extends BaseService<WalletKey, Long> {
     public Ed25519Key getPrivateKeyByWalletIdentifier(long walletId) {
         WalletKey wallet = walletKeyRepository.getByWalletId(walletId);
         String privateKey = encryptionUtils.decrypt(wallet.getPrivateKey());
-        byte[] content = new PemReader(new StringReader(privateKey)).readPemObject().getContent();
+        byte[] content = Base64.decode(privateKey);
         return Ed25519Key.asPrivateKey(content);
     }
 

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/StringToDidDocumentConverter.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/utils/StringToDidDocumentConverter.java
@@ -36,7 +36,7 @@ public class StringToDidDocumentConverter implements AttributeConverter<DidDocum
     @SneakyThrows
     @Override
     public String convertToDatabaseColumn(DidDocument didDocument) {
-        return URLDecoder.decode(didDocument.toJson(), StandardCharsets.UTF_8);
+        return didDocument.toJson();
     }
 
     @Override


### PR DESCRIPTION
- presentation should now be signed/issued by caller (not authority wallet)
- remove URL encoding of SSI objects that may contain a did:web, as it removed some of the did web encoding (%3A for encoded ':')
- updated SSI library to 0.0.7
- did:web are now correctly encoded, there was an issue when the host name contained a ':'