### PR TITLE
new integration tests for presentation validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation "org.testcontainers:testcontainers"
-	testImplementation "org.testcontainers:postgresql"
+	testImplementation 'com.h2database:h2:2.2.220'
 	testImplementation "org.testcontainers:junit-jupiter"
 	testImplementation group: 'com.github.dasniko', name: 'testcontainers-keycloak', version: '2.5.0'
 	testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/HoldersCredential.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/HoldersCredential.java
@@ -52,10 +52,10 @@ public class HoldersCredential extends MIWBaseEntity {
     @Column(nullable = false)
     private String issuerDid;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "credential_type")
     private String type;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name="credential_data")
     @Convert(converter = StringToCredentialConverter.class)
     private VerifiableCredential data;
 

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/IssuersCredential.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/dao/entity/IssuersCredential.java
@@ -52,10 +52,10 @@ public class IssuersCredential extends MIWBaseEntity {
     @Column(nullable = false)
     private String issuerDid;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name="credential_type")
     private String type;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name="credential_data")
     @Convert(converter = StringToCredentialConverter.class)
     private VerifiableCredential data;
 

--- a/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/HoldersCredentialService.java
+++ b/src/main/java/org/eclipse/tractusx/managedidentitywallets/service/HoldersCredentialService.java
@@ -104,11 +104,11 @@ public class HoldersCredentialService extends BaseService<HoldersCredential, Lon
 
         //Holder must be caller of API
         Wallet holderWallet = commonService.getWalletByIdentifier(callerBPN);
-        filterRequest.appendCriteria(StringPool.HOLDER_DID, Operator.EQUALS, holderWallet.getDid());
+        filterRequest.appendCriteria(StringPool.HOLDER_DID, Operator.EQUALS, holderWallet.getDid().toString());
 
         if (StringUtils.hasText(issuerIdentifier)) {
             Wallet issuerWallet = commonService.getWalletByIdentifier(issuerIdentifier);
-            filterRequest.appendCriteria(StringPool.ISSUER_DID, Operator.EQUALS, issuerWallet.getDid());
+            filterRequest.appendCriteria(StringPool.ISSUER_DID, Operator.EQUALS, issuerWallet.getDid().toString());
         }
 
         if (StringUtils.hasText(credentialId)) {

--- a/src/main/resources/db/changelog/changes/init.sql
+++ b/src/main/resources/db/changelog/changes/init.sql
@@ -1,74 +1,77 @@
 --liquibase formatted sql
 
 --changeset nitin:1
-CREATE TABLE public.wallet (
-  id bigserial NOT NULL,
-  name varchar(255) NOT NULL,
-  did varchar(255) NOT NULL,
-  bpn varchar(255) NOT NULL,
-  algorithm varchar(255) NOT NULL DEFAULT 'ED25519'::character varying,
-  did_document text NOT NULL,
-  created_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  modified_at timestamp(6) NULL,
-  modified_from varchar(255) NULL,
-  CONSTRAINT uk_bpn UNIQUE (bpn),
-  CONSTRAINT uk_did UNIQUE (did),
-  CONSTRAINT wallet_pkey PRIMARY KEY (id),
-  CONSTRAINT wallet_fk FOREIGN KEY (modified_from) REFERENCES public.wallet(bpn)
+CREATE TABLE IF NOT EXISTS public.wallet
+(
+    id            bigserial    NOT NULL,
+    name          varchar(255) NOT NULL,
+    did           varchar(255) NOT NULL,
+    bpn           varchar(255) NOT NULL,
+    algorithm     varchar(255) NOT NULL DEFAULT 'ED25519'::character varying,
+    did_document  text         NOT NULL,
+    created_at    timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at   timestamp(6) NULL,
+    modified_from varchar(255) NULL,
+    CONSTRAINT uk_bpn UNIQUE (bpn),
+    CONSTRAINT uk_did UNIQUE (did),
+    CONSTRAINT wallet_pkey PRIMARY KEY (id),
+    CONSTRAINT wallet_fk FOREIGN KEY (modified_from) REFERENCES public.wallet (bpn) ON DELETE SET NULL
 );
 COMMENT ON TABLE public.wallet IS 'This table will store wallets';
 
-
-CREATE TABLE public.wallet_key (
-  id bigserial NOT NULL,
-  wallet_id bigserial NOT NULL,
-  vault_access_token varchar(1000) NOT NULL,
-  reference_key varchar(255) NOT NULL,
-  private_key text NOT NULL,
-  public_key text NOT NULL,
-  created_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  modified_at timestamp(6) NULL,
-  modified_from varchar(255) NULL,
-  CONSTRAINT wallet_key_pkey PRIMARY KEY (id),
-  CONSTRAINT wallet_fk FOREIGN KEY (wallet_id) REFERENCES public.wallet(id),
-  CONSTRAINT wallet_key_fk FOREIGN KEY (modified_from) REFERENCES public.wallet(bpn)
+CREATE TABLE IF NOT EXISTS public.wallet_key
+(
+    id                 bigserial     NOT NULL,
+    wallet_id          bigserial     NOT NULL,
+    vault_access_token varchar(1000) NOT NULL,
+    reference_key      varchar(255)  NOT NULL,
+    private_key        text          NOT NULL,
+    public_key         text          NOT NULL,
+    created_at         timestamp(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at        timestamp(6)  NULL,
+    modified_from      varchar(255)  NULL,
+    CONSTRAINT wallet_key_pkey PRIMARY KEY (id),
+    CONSTRAINT wallet_fk_2 FOREIGN KEY (wallet_id) REFERENCES public.wallet (id) ON DELETE CASCADE,
+    CONSTRAINT wallet_key_fk FOREIGN KEY (modified_from) REFERENCES public.wallet (bpn) ON DELETE CASCADE
 );
 COMMENT ON TABLE public.wallet_key IS 'This table will store key pair of wallets';
 
 
-CREATE TABLE public.issuers_credential (
-  id bigserial NOT NULL,
-  holder_did varchar(255) NOT NULL,
-  issuer_did varchar(255) NOT NULL,
-  credential_id varchar(255) NOT NULL,
-  "data" text NOT NULL,
-  "type" varchar(255) NULL,
-  created_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  modified_at timestamp(6) NULL,
-  modified_from varchar(255) NULL,
-  CONSTRAINT issuers_credential_pkey PRIMARY KEY (id),
-  CONSTRAINT issuers_credential_fk FOREIGN KEY (modified_from) REFERENCES public.wallet(bpn),
-  CONSTRAINT issuers_credential_holder_wallet_fk FOREIGN KEY (holder_did) REFERENCES public.wallet(did)
+CREATE TABLE IF NOT EXISTS public.issuers_credential
+(
+    id            bigserial    NOT NULL,
+    holder_did    varchar(255) NOT NULL,
+    issuer_did    varchar(255) NOT NULL,
+    credential_id varchar(255) NOT NULL,
+    credential_data        text         NOT NULL,
+    credential_type        varchar(255) NULL,
+    created_at    timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at   timestamp(6) NULL,
+    modified_from varchar(255) NULL,
+    CONSTRAINT issuers_credential_pkey PRIMARY KEY (id),
+    CONSTRAINT issuers_credential_fk FOREIGN KEY (modified_from) REFERENCES public.wallet (bpn) ON DELETE SET NULL,
+    CONSTRAINT issuers_credential_holder_wallet_fk FOREIGN KEY (holder_did) REFERENCES public.wallet (did) ON DELETE CASCADE
 );
-COMMENT ON TABLE  public.issuers_credential IS 'This table will store issuers credentials';
+COMMENT ON TABLE public.issuers_credential IS 'This table will store issuers credentials';
 
 
-CREATE TABLE public.holders_credential (
-  id bigserial NOT NULL,
-  holder_did varchar(255) NOT NULL,
-  issuer_did varchar(255) NOT NULL,
-  credential_id varchar(255) NOT NULL,
-  "data" text NOT NULL,
-  "type" varchar(255) NULL,
-  is_self_issued bool NOT null default false,
-  is_stored bool NOT null default false,
-  created_at timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  modified_at timestamp(6) NULL,
-  modified_from varchar(255) NULL,
-  CONSTRAINT holders_credential_pkey PRIMARY KEY (id),
-  CONSTRAINT holders_credential_fk FOREIGN KEY (modified_from) REFERENCES public.wallet(bpn),
-  CONSTRAINT holders_credential_holder_wallet_fk FOREIGN KEY (holder_did) REFERENCES public.wallet(did)
+CREATE TABLE IF NOT EXISTS public.holders_credential
+(
+    id             bigserial    NOT NULL,
+    holder_did     varchar(255) NOT NULL,
+    issuer_did     varchar(255) NOT NULL,
+    credential_id  varchar(255) NOT NULL,
+    credential_data         text         NOT NULL,
+    credential_type         varchar(255) NULL,
+    is_self_issued bool         NOT null default false,
+    is_stored      bool         NOT null default false,
+    created_at     timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at    timestamp(6) NULL,
+    modified_from  varchar(255) NULL,
+    CONSTRAINT holders_credential_pkey PRIMARY KEY (id),
+    CONSTRAINT holders_credential_fk FOREIGN KEY (modified_from) REFERENCES public.wallet (bpn) ON DELETE SET NULL,
+    CONSTRAINT holders_credential_holder_wallet_fk FOREIGN KEY (holder_did) REFERENCES public.wallet (did) ON DELETE CASCADE
 );
-COMMENT ON TABLE  public.holders_credential IS 'This table will store holders credentials';
+COMMENT ON TABLE public.holders_credential IS 'This table will store holders credentials';
 
-COMMENT ON  COLUMN public.holders_credential.is_stored IS 'true is VC is stored using store VC api(Not issued by MIW)';
+COMMENT ON COLUMN public.holders_credential.is_stored IS 'true is VC is stored using store VC api(Not issued by MIW)';

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/did/DidDocumentsTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/did/DidDocumentsTest.java
@@ -24,12 +24,9 @@ package org.eclipse.tractusx.managedidentitywallets.did;
 import org.eclipse.tractusx.managedidentitywallets.ManagedIdentityWalletsApplication;
 import org.eclipse.tractusx.managedidentitywallets.config.TestContextInitializer;
 import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
-import org.eclipse.tractusx.managedidentitywallets.constant.StringPool;
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.Wallet;
-import org.eclipse.tractusx.managedidentitywallets.dao.repository.HoldersCredentialRepository;
-import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletKeyRepository;
-import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletRepository;
-import org.eclipse.tractusx.ssi.lib.model.did.DidDocument;
+import org.eclipse.tractusx.managedidentitywallets.dto.CreateWalletRequest;
+import org.eclipse.tractusx.managedidentitywallets.service.WalletService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,21 +38,14 @@ import org.springframework.test.context.ContextConfiguration;
 
 import java.util.UUID;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
 @ContextConfiguration(initializers = {TestContextInitializer.class})
 class DidDocumentsTest {
-    @Autowired
-    private WalletRepository walletRepository;
 
     @Autowired
-    private WalletKeyRepository walletKeyRepository;
-
-    @Autowired
-    private HoldersCredentialRepository holdersCredentialRepository;
-
+    private WalletService walletService;
     @Autowired
     private TestRestTemplate restTemplate;
-
 
     @Test
     void getDidDocumentInvalidBpn404() {
@@ -67,21 +57,9 @@ class DidDocumentsTest {
     void getDidDocumentWithBpn200() {
 
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        createWallet(bpn);
 
-        createWallet(bpn, did);
         ResponseEntity<String> response = restTemplate.getForEntity(RestURI.DID_DOCUMENTS, String.class, bpn);
-        Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
-        Assertions.assertNotNull(response.getBody());
-    }
-
-    @Test
-    void getDidDocumentWithDid200() {
-        String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
-
-        createWallet(bpn, did);
-        ResponseEntity<String> response = restTemplate.getForEntity(RestURI.DID_DOCUMENTS, String.class, did);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         Assertions.assertNotNull(response.getBody());
     }
@@ -96,37 +74,17 @@ class DidDocumentsTest {
     void getDidResolveWithBpn200() {
 
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
 
-        createWallet(bpn, did);
+        createWallet(bpn);
         ResponseEntity<String> response = restTemplate.getForEntity(RestURI.DID_RESOLVE, String.class, bpn);
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         Assertions.assertNotNull(response.getBody());
     }
 
-    private Wallet createWallet(String bpn, String did) {
-        String didDocument = """
-                {
-                  "id": "did:web:localhost%3Abpn123124",
-                  "verificationMethod": [
-                    {
-                      "publicKeyMultibase": "z9mo3TUPvEntiBQtHYVXXy5DfxLGgaHa84ZT6Er2qWs4y",
-                      "controller": "did:web:localhost%3Abpn123124",
-                      "id": "did:web:localhost%3Abpn123124#key-1",
-                      "type": "Ed25519VerificationKey2020"
-                    }
-                  ],
-                  "@context": "https://www.w3.org/ns/did/v1"
-                }
-                """;
-
-        Wallet wallet = Wallet.builder()
-                .bpn(bpn)
-                .did(did)
-                .didDocument(DidDocument.fromJson(didDocument))
-                .algorithm(StringPool.ED_25519)
-                .name(bpn)
-                .build();
-        return walletRepository.save(wallet);
+    private Wallet createWallet(String bpn) {
+        CreateWalletRequest createWalletRequest = new CreateWalletRequest();
+        createWalletRequest.setBpn(bpn);
+        createWalletRequest.setName("wallet_" + bpn);
+        return walletService.createWallet(createWalletRequest);
     }
 }

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/EncryptionTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/utils/EncryptionTest.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
 @ContextConfiguration(initializers = {TestContextInitializer.class})
 class EncryptionTest {
 

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/DismantlerHoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/DismantlerHoldersCredentialTest.java
@@ -40,6 +40,7 @@ import org.eclipse.tractusx.managedidentitywallets.dto.IssueDismantlerCredential
 import org.eclipse.tractusx.managedidentitywallets.dto.IssueMembershipCredentialRequest;
 import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebFactory;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.json.JSONException;
 import org.junit.jupiter.api.Assertions;
@@ -55,7 +56,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
 @ContextConfiguration(initializers = {TestContextInitializer.class})
 class DismantlerHoldersCredentialTest {
     @Autowired
@@ -80,7 +81,6 @@ class DismantlerHoldersCredentialTest {
     void issueDismantlerCredentialTest403() {
         String bpn = UUID.randomUUID().toString();
 
-        String did = "did:web:localhost:" + bpn;
         HttpHeaders headers = AuthenticationUtils.getInvalidUserHttpHeaders();
 
         IssueMembershipCredentialRequest request = IssueMembershipCredentialRequest.builder().bpn(bpn).build();
@@ -93,7 +93,7 @@ class DismantlerHoldersCredentialTest {
 
 
     @Test
-    void issueDismantlerCredentialToBaseWalletTest201() throws JsonProcessingException, JSONException {
+    void issueDismantlerCredentialToBaseWalletTest201() throws JSONException {
         Wallet wallet = walletRepository.getByBpn(miwSettings.authorityWalletBpn());
         String oldSummaryCredentialId = TestUtils.getSummaryCredentialId(wallet.getDid(), holdersCredentialRepository);
         ResponseEntity<String> response = issueDismantlerCredential(miwSettings.authorityWalletBpn(), miwSettings.authorityWalletBpn());
@@ -111,7 +111,7 @@ class DismantlerHoldersCredentialTest {
     void issueDismantlerCredentialTest201() throws JsonProcessingException, JSONException {
 
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         //create wallet
         Wallet wallet = TestUtils.getWalletFromString(TestUtils.createWallet(bpn, bpn, restTemplate).getBody());
@@ -154,7 +154,7 @@ class DismantlerHoldersCredentialTest {
     void issueDismantlerCredentialWithInvalidBpnAccess409() {
         String bpn = UUID.randomUUID().toString();
 
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         //create entry
         Wallet wallet = TestUtils.createWallet(bpn, did, walletRepository);
@@ -178,7 +178,7 @@ class DismantlerHoldersCredentialTest {
     @Test
     void issueDismantlerCredentialWithoutAllowedVehicleBrands() {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost%3A8080:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         Wallet wallet = TestUtils.createWallet(bpn, did, walletRepository);
 
         HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders(miwSettings.authorityWalletBpn()); //token must contain base wallet BPN
@@ -200,8 +200,7 @@ class DismantlerHoldersCredentialTest {
     void issueDismantlerCredentialWithDuplicateBpn409() {
 
         String bpn = UUID.randomUUID().toString();
-
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         //create entry
         Wallet wallet = TestUtils.createWallet(bpn, did, walletRepository);

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/FrameworkHoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/FrameworkHoldersCredentialTest.java
@@ -34,12 +34,12 @@ import org.eclipse.tractusx.managedidentitywallets.dao.entity.IssuersCredential;
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.Wallet;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.HoldersCredentialRepository;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.IssuersCredentialRepository;
-import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletKeyRepository;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletRepository;
 import org.eclipse.tractusx.managedidentitywallets.dto.IssueFrameworkCredentialRequest;
 import org.eclipse.tractusx.managedidentitywallets.dto.IssueMembershipCredentialRequest;
 import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebFactory;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.json.JSONException;
 import org.junit.jupiter.api.Assertions;
@@ -58,16 +58,13 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
 @ContextConfiguration(initializers = {TestContextInitializer.class})
 class FrameworkHoldersCredentialTest {
     @Autowired
     private HoldersCredentialRepository holdersCredentialRepository;
     @Autowired
     private WalletRepository walletRepository;
-
-    @Autowired
-    private WalletKeyRepository walletKeyRepository;
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -78,13 +75,11 @@ class FrameworkHoldersCredentialTest {
     @Autowired
     private IssuersCredentialRepository issuersCredentialRepository;
 
-    private static int count = 0;
-
 
     @Test
     void issueFrameworkCredentialTest403() {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         HttpHeaders headers = AuthenticationUtils.getInvalidUserHttpHeaders();
 
         IssueMembershipCredentialRequest request = IssueMembershipCredentialRequest.builder().bpn(bpn).build();
@@ -95,11 +90,10 @@ class FrameworkHoldersCredentialTest {
         Assertions.assertEquals(HttpStatus.FORBIDDEN.value(), response.getStatusCode().value());
     }
 
-
     @Test
     void issueFrameworkCredentialWithInvalidBpnAccessTest403() throws JsonProcessingException, JSONException {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         TestUtils.createWallet(bpn, did, walletRepository);
 
         String type = "BehaviorTwinCredential";
@@ -148,7 +142,7 @@ class FrameworkHoldersCredentialTest {
     @MethodSource("getTypes")
     void issueFrameWorkVCTest201(IssueFrameworkCredentialRequest request) throws JsonProcessingException, JSONException {
         String bpn = request.getHolderIdentifier();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         String type = request.getType();
 
@@ -174,7 +168,7 @@ class FrameworkHoldersCredentialTest {
     @DisplayName("Issue framework with invalid type")
     void issueFrameworkCredentialTest400() throws JsonProcessingException, JSONException {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         Wallet wallet = TestUtils.createWallet(bpn, did, walletRepository);
 
 

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/HoldersCredentialTest.java
@@ -38,6 +38,7 @@ import org.eclipse.tractusx.managedidentitywallets.dto.IssueFrameworkCredentialR
 import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
 import org.eclipse.tractusx.ssi.lib.did.resolver.DidDocumentResolverRegistryImpl;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebFactory;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialBuilder;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialSubject;
@@ -62,7 +63,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.*;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
 @ContextConfiguration(initializers = {TestContextInitializer.class})
 @ExtendWith(MockitoExtension.class)
 class HoldersCredentialTest {
@@ -85,7 +86,7 @@ class HoldersCredentialTest {
     @Test
     void issueCredentialTestWithInvalidBPNAccess403() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         String type = "TestCredential";
         HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders("not valid BPN");
 
@@ -99,7 +100,7 @@ class HoldersCredentialTest {
     @Test
     void issueCredentialTest200() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         String type = "TestCredential";
         HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders(bpn);
 
@@ -115,7 +116,6 @@ class HoldersCredentialTest {
         TestUtils.checkVC(credentials.get(0).getData(), miwSettings);
         Assertions.assertTrue(credentials.get(0).isSelfIssued());
         Assertions.assertFalse(credentials.get(0).isStored());
-
     }
 
 
@@ -137,7 +137,7 @@ class HoldersCredentialTest {
 
         String baseDID = miwSettings.authorityWalletDid();
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders(bpn);
         //save wallet
         TestUtils.createWallet(bpn, did, walletRepository);
@@ -273,7 +273,7 @@ class HoldersCredentialTest {
         //Using Builder
         VerifiableCredential credentialWithoutProof =
                 verifiableCredentialBuilder
-                        .id(URI.create(did + "#" + UUID.randomUUID().toString()))
+                        .id(URI.create(did + "#" + UUID.randomUUID()))
                         .context(miwSettings.vcContexts())
                         .type(List.of(VerifiableCredentialType.VERIFIABLE_CREDENTIAL, type))
                         .issuer(URI.create(did)) //issuer must be base wallet

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/IssuersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/IssuersCredentialTest.java
@@ -38,6 +38,7 @@ import org.eclipse.tractusx.managedidentitywallets.dto.CreateWalletRequest;
 import org.eclipse.tractusx.managedidentitywallets.dto.IssueFrameworkCredentialRequest;
 import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebFactory;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialBuilder;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredentialSubject;
@@ -56,7 +57,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.*;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
 @ContextConfiguration(initializers = {TestContextInitializer.class})
 class IssuersCredentialTest {
 
@@ -102,7 +103,6 @@ class IssuersCredentialTest {
             ResponseEntity<String> exchange = restTemplate.exchange(RestURI.API_CREDENTIALS_ISSUER_FRAMEWORK, HttpMethod.POST, entity, String.class);
             Assertions.assertEquals(exchange.getStatusCode().value(), HttpStatus.CREATED.value());
         }
-
 
         HttpEntity<Map> entity = new HttpEntity<>(headers);
 
@@ -162,7 +162,7 @@ class IssuersCredentialTest {
     @Test
     void issueCredentialsWithoutBaseWalletBPN403() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
-        String holderDid = "did:web:localhost:" + bpn;
+        String holderDid = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         String type = "TestCredential";
         HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders(bpn);
 
@@ -193,7 +193,7 @@ class IssuersCredentialTest {
     void issueSummaryCredentials400() throws com.fasterxml.jackson.core.JsonProcessingException {
 
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders(miwSettings.authorityWalletBpn());
 
         ResponseEntity<String> response = issueVC(bpn, did, miwSettings.authorityWalletDid(), MIWVerifiableCredentialType.SUMMARY_CREDENTIAL, headers);
@@ -205,7 +205,7 @@ class IssuersCredentialTest {
     void issueCredentials200() throws com.fasterxml.jackson.core.JsonProcessingException {
 
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         String type = "TestCredential";
         HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders(miwSettings.authorityWalletBpn());
 
@@ -245,7 +245,7 @@ class IssuersCredentialTest {
         //Using Builder
         VerifiableCredential credentialWithoutProof =
                 verifiableCredentialBuilder
-                        .id(URI.create(miwSettings.authorityWalletDid() + "#" + UUID.randomUUID().toString()))
+                        .id(URI.create(issuerDid + "#" + UUID.randomUUID()))
                         .context(miwSettings.vcContexts())
                         .type(List.of(VerifiableCredentialType.VERIFIABLE_CREDENTIAL, type))
                         .issuer(URI.create(issuerDid)) //issuer must be base wallet

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/MembershipHoldersCredentialTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/MembershipHoldersCredentialTest.java
@@ -34,11 +34,11 @@ import org.eclipse.tractusx.managedidentitywallets.dao.entity.IssuersCredential;
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.Wallet;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.HoldersCredentialRepository;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.IssuersCredentialRepository;
-import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletKeyRepository;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletRepository;
 import org.eclipse.tractusx.managedidentitywallets.dto.IssueMembershipCredentialRequest;
 import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebFactory;
 import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
@@ -55,7 +55,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
 @ContextConfiguration(initializers = {TestContextInitializer.class})
 class MembershipHoldersCredentialTest {
     @Autowired
@@ -63,8 +63,6 @@ class MembershipHoldersCredentialTest {
     @Autowired
     private WalletRepository walletRepository;
 
-    @Autowired
-    private WalletKeyRepository walletKeyRepository;
     @Autowired
     private TestRestTemplate restTemplate;
 
@@ -82,7 +80,7 @@ class MembershipHoldersCredentialTest {
     void issueMembershipCredentialTest403() {
         String bpn = UUID.randomUUID().toString();
 
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         HttpHeaders headers = AuthenticationUtils.getInvalidUserHttpHeaders();
 
@@ -97,7 +95,7 @@ class MembershipHoldersCredentialTest {
     @Test
     void testIssueSummeryVCAfterDeleteSummaryVCFromHolderWallet() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         // create wallet, in background bpn and summary credential generated
         Wallet wallet = TestUtils.getWalletFromString(TestUtils.createWallet(bpn, bpn, restTemplate).getBody());
@@ -125,7 +123,7 @@ class MembershipHoldersCredentialTest {
     @Test
     void testStoredSummaryVCTest() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         // create wallet, in background bpn and summary credential generated
         Wallet wallet = TestUtils.getWalletFromString(TestUtils.createWallet(bpn, bpn, restTemplate).getBody());
@@ -187,7 +185,7 @@ class MembershipHoldersCredentialTest {
     @Test
     void issueMembershipCredentialToBaseWalletTest400() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         // create wallet, in background bpn and summary credential generated
         Wallet wallet = TestUtils.getWalletFromString(TestUtils.createWallet(bpn, bpn, restTemplate).getBody());
@@ -258,7 +256,7 @@ class MembershipHoldersCredentialTest {
 
         TestUtils.checkVC(verifiableCredential, miwSettings);
 
-        validateTypes(verifiableCredential, miwSettings.authorityWalletBpn());
+        validateTypes(verifiableCredential);
 
         List<HoldersCredential> holderVCs = holdersCredentialRepository.getByHolderDidAndType(wallet.getDid(), MIWVerifiableCredentialType.MEMBERSHIP_CREDENTIAL);
         Assertions.assertFalse(holderVCs.isEmpty());
@@ -292,7 +290,7 @@ class MembershipHoldersCredentialTest {
 
         TestUtils.checkVC(verifiableCredential, miwSettings);
 
-        validateTypes(verifiableCredential, bpn);
+        validateTypes(verifiableCredential);
 
         List<HoldersCredential> holderVCs = holdersCredentialRepository.getByHolderDidAndType(wallet.getDid(), MIWVerifiableCredentialType.MEMBERSHIP_CREDENTIAL);
         Assertions.assertFalse(holderVCs.isEmpty());
@@ -316,7 +314,7 @@ class MembershipHoldersCredentialTest {
     void issueMembershipCredentialWithInvalidBpnAccess409() {
         String bpn = UUID.randomUUID().toString();
 
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         //save wallet
         TestUtils.createWallet(bpn, did, walletRepository);
@@ -334,7 +332,7 @@ class MembershipHoldersCredentialTest {
 
         String bpn = UUID.randomUUID().toString();
 
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         //save wallet
         TestUtils.createWallet(bpn, did, walletRepository);
@@ -354,8 +352,8 @@ class MembershipHoldersCredentialTest {
         return new VerifiableCredential(map);
     }
 
-    private void validateTypes(VerifiableCredential verifiableCredential, String holderBpn) {
+    private void validateTypes(VerifiableCredential verifiableCredential) {
         Assertions.assertTrue(verifiableCredential.getTypes().contains(MIWVerifiableCredentialType.MEMBERSHIP_CREDENTIAL));
-        Assertions.assertEquals(verifiableCredential.getCredentialSubject().get(0).get(StringPool.HOLDER_IDENTIFIER), holderBpn);
+        Assertions.assertEquals(verifiableCredential.getCredentialSubject().get(0).get(StringPool.MEMBER_OF), "Test-X");
     }
 }

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/PresentationValidationTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vc/PresentationValidationTest.java
@@ -1,0 +1,212 @@
+/*
+ * *******************************************************************************
+ *  Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ******************************************************************************
+ */
+
+package org.eclipse.tractusx.managedidentitywallets.vc;
+
+import lombok.*;
+import org.eclipse.tractusx.managedidentitywallets.ManagedIdentityWalletsApplication;
+import org.eclipse.tractusx.managedidentitywallets.config.MIWSettings;
+import org.eclipse.tractusx.managedidentitywallets.config.TestContextInitializer;
+import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
+import org.eclipse.tractusx.managedidentitywallets.constant.StringPool;
+import org.eclipse.tractusx.managedidentitywallets.dao.entity.Wallet;
+import org.eclipse.tractusx.managedidentitywallets.dto.CreateWalletRequest;
+import org.eclipse.tractusx.managedidentitywallets.dto.IssueMembershipCredentialRequest;
+import org.eclipse.tractusx.managedidentitywallets.exception.WalletNotFoundProblem;
+import org.eclipse.tractusx.managedidentitywallets.service.IssuersCredentialService;
+import org.eclipse.tractusx.managedidentitywallets.service.PresentationService;
+import org.eclipse.tractusx.managedidentitywallets.service.WalletService;
+import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
+import org.eclipse.tractusx.ssi.lib.model.did.Did;
+import org.eclipse.tractusx.ssi.lib.model.did.DidParser;
+import org.eclipse.tractusx.ssi.lib.model.verifiable.credential.VerifiableCredential;
+import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentation;
+import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentationBuilder;
+import org.eclipse.tractusx.ssi.lib.model.verifiable.presentation.VerifiablePresentationType;
+import org.eclipse.tractusx.ssi.lib.serialization.SerializeUtil;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@ContextConfiguration(initializers = {TestContextInitializer.class})
+@Disabled("Disabled until Membership Credentials are Json-LD compliant")
+public class PresentationValidationTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Autowired
+    private WalletService walletService;
+    @Autowired
+    private IssuersCredentialService issuersCredentialService;
+    @Autowired
+    private PresentationService presentationService;
+    @Autowired
+    private TestRestTemplate restTemplate;
+    @Autowired
+    private MIWSettings miwSettings;
+
+    private final String bpnTenant_1 = UUID.randomUUID().toString();
+    private  final String bpnTenant_2 = UUID.randomUUID().toString();
+    private String bpnOperator;
+    private Did tenant_1;
+    private Did tenant_2;
+    private VerifiableCredential membershipCredential_1;
+    private VerifiableCredential membershipCredential_2;
+
+    @BeforeEach
+    public void setup() {
+        bpnOperator = miwSettings.authorityWalletBpn();
+
+        final CreateWalletRequest createWalletRequest = new CreateWalletRequest();
+        createWalletRequest.setBpn(bpnTenant_1);
+        createWalletRequest.setName("My Test Tenant Wallet");
+        final Wallet tenantWallet = walletService.createWallet(createWalletRequest);
+        tenant_1 = DidParser.parse(tenantWallet.getDid());
+
+        final CreateWalletRequest createWalletRequest2 = new CreateWalletRequest();
+        createWalletRequest2.setBpn(bpnTenant_2);
+        createWalletRequest2.setName("My Test Tenant Wallet");
+        final Wallet tenantWallet2 = walletService.createWallet(createWalletRequest2);
+        tenant_2 = DidParser.parse(tenantWallet2.getDid());
+
+        final IssueMembershipCredentialRequest issueMembershipCredentialRequest = new IssueMembershipCredentialRequest();
+        issueMembershipCredentialRequest.setBpn(bpnTenant_1);
+        membershipCredential_1 = issuersCredentialService.issueMembershipCredential(issueMembershipCredentialRequest, bpnOperator);
+
+        final IssueMembershipCredentialRequest issueMembershipCredentialRequest2 = new IssueMembershipCredentialRequest();
+        issueMembershipCredentialRequest2.setBpn(bpnTenant_2);
+        membershipCredential_2 = issuersCredentialService.issueMembershipCredential(issueMembershipCredentialRequest2, bpnOperator);
+    }
+
+    @AfterEach
+    public void cleanUp(){
+        try {
+            Wallet tenantWallet = walletService.getWalletByIdentifier(bpnTenant_1, false, bpnOperator);
+            walletService.delete(tenantWallet.getId());
+        } catch (WalletNotFoundProblem e) {
+            // ignore
+        }
+        try {
+            Wallet tenantWallet = walletService.getWalletByIdentifier(bpnTenant_2, false, bpnOperator);
+            walletService.delete(tenantWallet.getId());
+        } catch (WalletNotFoundProblem e) {
+            // ignore
+        }
+    }
+
+    @Test
+    public void testSuccessfulValidation() {
+        final Map<String, Object> presentation = createPresentationJwt(membershipCredential_1, tenant_1);
+        VerifiablePresentationValidationResponse response = validateJwtOfCredential(presentation);
+        Assertions.assertTrue(response.valid);
+    }
+
+    @Test
+    public void testValidationFailureOfCredentialWitInvalidExpirationDate() {
+        // test is related to this old issue where the signature check still succeeded
+        // https://github.com/eclipse-tractusx/SSI-agent-lib/issues/4
+        final VerifiableCredential copyCredential = new VerifiableCredential(membershipCredential_1);
+        // e.g. an attacker tries to extend the validity of a verifiable credential
+        copyCredential.put(VerifiableCredential.EXPIRATION_DATE, "2500-09-30T22:00:00Z");
+        final Map<String, Object> presentation = createPresentationJwt(copyCredential, tenant_1);
+        VerifiablePresentationValidationResponse response = validateJwtOfCredential(presentation);
+        Assertions.assertFalse(response.valid);
+    }
+
+    @Test
+    @SneakyThrows
+    public void testValidationFailureOfPresentationPayloadManipulation() {
+        final Map<String, Object> presentation = createPresentationJwt(membershipCredential_1, tenant_1);
+
+        final String jwt = (String) presentation.get(StringPool.VP);
+        final String payload = jwt.split("\\.")[1];
+        Base64.Decoder decoder = Base64.getUrlDecoder();
+        Base64.Encoder encoder = Base64.getUrlEncoder();
+
+        final byte[] payloadDecoded = decoder.decode(payload);
+        final Map<String, Object> payloadMap = OBJECT_MAPPER.readValue(payloadDecoded, Map.class);
+
+        // replace with credential of another tenant
+        final VerifiablePresentation newPresentation = new VerifiablePresentationBuilder()
+                .context(List.of(VerifiablePresentation.DEFAULT_CONTEXT))
+                .id(URI.create(UUID.randomUUID().toString()))
+                .type(List.of(VerifiablePresentationType.VERIFIABLE_PRESENTATION))
+                .verifiableCredentials(List.of(membershipCredential_2))
+                .build();
+        payloadMap.put("vp", newPresentation);
+        final String newPayloadJson = OBJECT_MAPPER.writeValueAsString(payloadMap);
+        final String newPayloadEncoded = encoder.encodeToString(newPayloadJson.getBytes());
+
+        final String newJwt = jwt.split("\\.")[0] + "." + newPayloadEncoded + "." + jwt.split("\\.")[2];
+
+        VerifiablePresentationValidationResponse response = validateJwtOfCredential(Map.of(
+                StringPool.VP, newJwt
+        ));
+        Assertions.assertNotEquals(jwt, newJwt);
+        Assertions.assertFalse(response.valid, String.format("The validation should fail because the vp is manipulated.\nOriginal JWT: %s\nNew JWT: %s", jwt, newJwt));
+    }
+
+    @SneakyThrows
+    private VerifiablePresentationValidationResponse validateJwtOfCredential(Map<String, Object> presentationJwt) {
+        final HttpHeaders headers = AuthenticationUtils.getValidUserHttpHeaders(miwSettings.authorityWalletBpn());
+        headers.set("Content-Type", "application/json");
+        final HttpEntity<Map> entity = new HttpEntity<>(presentationJwt, headers);
+
+        final ResponseEntity<String> response = restTemplate.exchange(RestURI.API_PRESENTATIONS_VALIDATION + "?asJwt=true", HttpMethod.POST, entity, String.class);
+
+        if (response.getStatusCode().is2xxSuccessful()) {
+            return OBJECT_MAPPER.readValue(response.getBody(), VerifiablePresentationValidationResponse.class);
+        }
+
+        throw new RuntimeException(String.format("JWT:\n%s\nResponse: %s",
+                SerializeUtil.toPrettyJson(presentationJwt),
+                OBJECT_MAPPER.writeValueAsString(response)));
+    }
+
+    private Map<String, Object> createPresentationJwt(VerifiableCredential verifiableCredential, Did issuer) {
+        return presentationService.createPresentation(Map.of(StringPool.VERIFIABLE_CREDENTIALS, List.of(verifiableCredential)),
+                true, issuer.toString(), issuer.toString());
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    private static class VerifiablePresentationValidationResponse {
+        boolean valid;
+        String vp;
+    }
+}

--- a/src/test/java/org/eclipse/tractusx/managedidentitywallets/vp/PresentationTest.java
+++ b/src/test/java/org/eclipse/tractusx/managedidentitywallets/vp/PresentationTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.tractusx.managedidentitywallets.ManagedIdentityWalletsApplication;
+import org.eclipse.tractusx.managedidentitywallets.config.MIWSettings;
 import org.eclipse.tractusx.managedidentitywallets.config.TestContextInitializer;
 import org.eclipse.tractusx.managedidentitywallets.constant.MIWVerifiableCredentialType;
 import org.eclipse.tractusx.managedidentitywallets.constant.RestURI;
@@ -34,17 +35,15 @@ import org.eclipse.tractusx.managedidentitywallets.controller.PresentationContro
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.HoldersCredential;
 import org.eclipse.tractusx.managedidentitywallets.dao.entity.Wallet;
 import org.eclipse.tractusx.managedidentitywallets.dao.repository.HoldersCredentialRepository;
-import org.eclipse.tractusx.managedidentitywallets.dao.repository.WalletRepository;
-import org.eclipse.tractusx.managedidentitywallets.service.PresentationService;
 import org.eclipse.tractusx.managedidentitywallets.utils.AuthenticationUtils;
 import org.eclipse.tractusx.managedidentitywallets.utils.TestUtils;
 import org.eclipse.tractusx.ssi.lib.did.resolver.DidDocumentResolverRegistry;
+import org.eclipse.tractusx.ssi.lib.did.web.DidWebFactory;
 import org.eclipse.tractusx.ssi.lib.exception.DidDocumentResolverNotRegisteredException;
 import org.eclipse.tractusx.ssi.lib.exception.JwtException;
 import org.eclipse.tractusx.ssi.lib.jwt.SignedJwtVerifier;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
@@ -60,12 +59,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ManagedIdentityWalletsApplication.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {ManagedIdentityWalletsApplication.class})
 @ContextConfiguration(initializers = {TestContextInitializer.class})
 class PresentationTest {
-
-    @Autowired
-    private WalletRepository walletRepository;
 
     @Autowired
     private TestRestTemplate restTemplate;
@@ -77,14 +73,14 @@ class PresentationTest {
     private ObjectMapper objectMapper;
 
     @Autowired
-    private PresentationService presentationService;
+    private PresentationController presentationController;
 
     @Autowired
-    private PresentationController presentationController;
+    private MIWSettings miwSettings;
 
 
     @Test
-    void validateVPAssJsonLd400() throws JsonProcessingException, DidDocumentResolverNotRegisteredException, JwtException, InterruptedException {
+    void validateVPAssJsonLd400() throws JsonProcessingException {
         //create VP
         String bpn = UUID.randomUUID().toString();
         String audience = "companyA";
@@ -101,31 +97,22 @@ class PresentationTest {
 
 
     @Test
-    @Disabled("Temporarily disabled, as presentation validation requires real did resolving, which does not work yet for integration tests")
-    void validateVPAsJwt() throws JsonProcessingException, DidDocumentResolverNotRegisteredException, JwtException, InterruptedException {
+    void validateVPAsJwt() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
         String audience = "companyA";
         ResponseEntity<Map> vpResponse = createBpnVCAsJwt(bpn, audience);
         Map body = vpResponse.getBody();
 
-        try (MockedConstruction SignedJwtVerifierMock = Mockito.mockConstruction(SignedJwtVerifier.class)) {
-            DidDocumentResolverRegistry didDocumentResolverRegistry = Mockito.mock(DidDocumentResolverRegistry.class);
-            SignedJwtVerifier signedJwtVerifier = new SignedJwtVerifier(didDocumentResolverRegistry);
+        ResponseEntity<Map<String, Object>> mapResponseEntity = presentationController.validatePresentation(body, null, true, false);
 
-            Mockito.doReturn(true).when(signedJwtVerifier).verify(Mockito.any(SignedJWT.class));
+        Map map = mapResponseEntity.getBody();
 
-            ResponseEntity<Map<String, Object>> mapResponseEntity = presentationController.validatePresentation(body, null, true, false);
-
-            Map map = mapResponseEntity.getBody();
-
-            Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALID).toString()));
-            Assertions.assertFalse(map.containsKey(StringPool.VALIDATE_AUDIENCE));
-            Assertions.assertFalse(map.containsKey(StringPool.VALIDATE_EXPIRY_DATE));
-        }
+        Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALID).toString()));
+        Assertions.assertFalse(map.containsKey(StringPool.VALIDATE_AUDIENCE));
+        Assertions.assertFalse(map.containsKey(StringPool.VALIDATE_EXPIRY_DATE));
     }
 
     @Test
-    @Disabled("Temporarily disabled, as presentation validation requires real did resolving, which does not work yet for integration tests")
     void validateVPAsJwtWithInvalidSignatureAndInValidAudienceAndExpiryDateValidation() throws JsonProcessingException, DidDocumentResolverNotRegisteredException, JwtException, InterruptedException {
         //create VP
         String bpn = UUID.randomUUID().toString();
@@ -154,36 +141,26 @@ class PresentationTest {
     }
 
     @Test
-    @Disabled("Temporarily disabled, as presentation validation requires real did resolving, which does not work yet for integration tests")
-    void validateVPAsJwtWithValidAudienceAndDateValidation() throws JsonProcessingException, DidDocumentResolverNotRegisteredException, JwtException {
+    void validateVPAsJwtWithValidAudienceAndDateValidation() throws JsonProcessingException{
         //create VP
         String bpn = UUID.randomUUID().toString();
         String audience = "companyA";
         ResponseEntity<Map> vpResponse = createBpnVCAsJwt(bpn, audience);
         Map body = vpResponse.getBody();
 
-        try (MockedConstruction<SignedJwtVerifier> mocked = Mockito.mockConstruction(SignedJwtVerifier.class)) {
+        ResponseEntity<Map<String, Object>> mapResponseEntity = presentationController.validatePresentation(body, audience, true, true);
 
-            DidDocumentResolverRegistry didDocumentResolverRegistry = Mockito.mock(DidDocumentResolverRegistry.class);
-            SignedJwtVerifier signedJwtVerifier = new SignedJwtVerifier(didDocumentResolverRegistry);
-            Mockito.doReturn(true).when(signedJwtVerifier).verify(Mockito.any(SignedJWT.class));
+        Map map = mapResponseEntity.getBody();
 
-
-            ResponseEntity<Map<String, Object>> mapResponseEntity = presentationController.validatePresentation(body, audience, true, true);
-
-            Map map = mapResponseEntity.getBody();
-
-            Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALID).toString()));
-            Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALIDATE_AUDIENCE).toString()));
-            Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALIDATE_EXPIRY_DATE).toString()));
-
-        }
+        Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALID).toString()));
+        Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALIDATE_AUDIENCE).toString()));
+        Assertions.assertTrue(Boolean.parseBoolean(map.get(StringPool.VALIDATE_EXPIRY_DATE).toString()));
     }
 
     @Test
     void createPresentationAsJWT201() throws JsonProcessingException, ParseException {
         String bpn = UUID.randomUUID().toString();
-        String did = "did:web:localhost:" + bpn;
+        String did = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
         String audience = "companyA";
         ResponseEntity<Map> vpResponse = createBpnVCAsJwt(bpn, audience);
         Assertions.assertEquals(vpResponse.getStatusCode().value(), HttpStatus.CREATED.value());
@@ -197,7 +174,7 @@ class PresentationTest {
     }
 
     private ResponseEntity<Map> createBpnVCAsJwt(String bpn, String audience) throws JsonProcessingException {
-        String didWeb = "did:web:localhost:" + bpn;
+        String didWeb = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         Map<String, Object> request = getIssueVPRequest(bpn);
 
@@ -215,7 +192,7 @@ class PresentationTest {
     void createPresentationAsJsonLD201() throws JsonProcessingException {
 
         String bpn = UUID.randomUUID().toString();
-        String didWeb = "did:web:localhost:" + bpn;
+        String didWeb = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         Map<String, Object> request = getIssueVPRequest(bpn);
 
@@ -232,7 +209,7 @@ class PresentationTest {
     @Test
     void createPresentationWithInvalidBPNAccess403() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
-        String didWeb = "did:web:localhost:" + bpn;
+        String didWeb = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         Map<String, Object> request = getIssueVPRequest(bpn);
 
@@ -248,7 +225,7 @@ class PresentationTest {
     @Test
     void createPresentationWithMoreThenOneVC400() throws JsonProcessingException {
         String bpn = UUID.randomUUID().toString();
-        String didWeb = "did:web:localhost:" + bpn;
+        String didWeb = DidWebFactory.fromHostnameAndPath(miwSettings.host(), bpn).toString();
 
         ResponseEntity<String> response = TestUtils.createWallet(bpn, bpn, restTemplate);
         Assertions.assertEquals(response.getStatusCode().value(), HttpStatus.CREATED.value());


### PR DESCRIPTION
- replaced postgres with in-memory h2 database during integration test runs
- renamed columns with protected table names:
  - 'type' column is now called 'credential_type'
  - 'data' column is now called 'credential_data'
- add cascading deletes to the sql schema, so that wallets can be easily removed between tests
- free port is now defined before test initialize, to use port number if various application settings
- add presentation validation tests and disabled them, as membership credential is currently not json-ld compliant
- replaced dids in other integration tests with resolvable ones 